### PR TITLE
fixing ngs_process_bismark scripts to allow for re-analysis of old data

### DIFF
--- a/docs/BSPCR-protocol.md
+++ b/docs/BSPCR-protocol.md
@@ -61,13 +61,13 @@ Due to the unique characteristics of bisulfite-converted DNA, PCRs on bisulfite-
     * Vortexing briefly seems to produce more consistent results than flicking and inverting the tubes. 
 5. Load the tubes into a thermocycler, and use the following program: 
     #### Table 3: Thermocycling protocol for Phusion U 
-    | Temperature | Duration  |
-    | ----------- | --------- |
-    | 98°C        | 30s       |
-    | 98°C        | 10s (x40) |
-    | X°C         | 30s (x40) |
-    | 72°C        | 30s (x40) |
-    | 72°C        | 10 min    |
+    | Stage   | Temperature | Duration |
+    | ------- | ----------- | -------- |
+    | 1       | 98°C        | 30s      |
+    | 2 (x45) | 98°C        | 10s      |
+    |         | X°C         | 30s      |
+    |         | 72°C        | 30s      |
+    | 3       | 72°C        | 10 min   |
 6. To confirm the success of the PCR, perform agarose gel electrophoresis. Prepare a 2% gel. Load 3 uL of PCR product mixed with 3 uL of loading dye into each well. Load 1 uL of ladder mixed with 3 uL of loading dye and 3 uL of water. Run the gel at 120 V for 40 minutes. 
 7. For PCR optimization, prepare 6-9 replicates of each PCR and test them in 1 C increments in the Quantstudio 5. These PCR sets are extremely sensitivie to the annealing temperature. 
 

--- a/docs/BSPCR-protocol.md
+++ b/docs/BSPCR-protocol.md
@@ -1,0 +1,77 @@
+# Bisulfite PCR protocol
+## Background
+Bisulfite conversion of DNA is a method of deaminating unmethylated cytosines into uracil, leaving only 5-methylcytosine (5mC) and its other forms intact. This technique is used in the analysis of methylation status of DNA. By performing the bisulfite conversion, sequencing the converted DNA, and comparing the converted sequence to an unconverted reference, we can identify which cytosines are methylated, as they will be read as cytosine while unconverted cytosines will be read as thymine. 
+
+Note that the conversion process causes both strands of DNA to no longer be complementary to each other. This is due to unmethylated cytosines getting converted to uracil (and subsequently thymine after PCR), resulting in G-T mismatches across both strands. Therefore, bisulfite-converted DNA is single-stranded and is significantly less stable. Bisulfite-converted DNA also has the tendency to form complex secondary structures due to its single-strandedness. Finally, bisulfite-conversion is damaging to DNA due to the high alkalinity and temperatures required in the reaction. As a result, bisulfite-converted DNA will often be fragmented.
+
+Due to the unique characteristics of bisulfite-converted DNA, PCRs on bisulfite-treated DNA require additional considerations: 
+* Primers for PCRs on bisulfite-treated DNA must be designed to target bisulfite-treated DNA. Ideally, primers should not have any CG dinucleotides in them, as these CGs may be either be a C or a T depending on their methylation status. If CGs are present in the primers, they should be placed on the 5’ end of the primer. Conventional primer design programs cannot be used to design these primers. See the ‘Bisulfite PCR Primers Design using Bisearch’ protocol for more details. 
+
+* Since both strands of DNA are non-complementary and unique after bisulfite-conversion, any primers that are designed will only amplify off one strand. Therefore, to completely assess the methylation status of any region, at least two sets of primers are required. 
+
+* The complex secondary structures formed by bisulfite-converted DNA often mean that PCRs will require the use of PCR additives and buffers that disrupt base-pairing and secondary structure formation. In my experience, both betaine and DMSO are both needed. For Phusion U, using the Phusion GC buffer significantly increases the success rate of the BSPCR, as the GC buffer is also designed to disrupt base-pairing and secondary structure formation. 
+
+* Because of bisulfite-converted DNA is fragmented, there is an upper limit to the size of amplicon that can be produced by PCR. Generally, good yields will be obtained from PCRs of <300 bp fragments, with worse and worse yields up to ~600 bp. 
+
+* Fragmentation as well as incomplete bisulfite conversion of priming sites reduce the number of amplifiable copies of DNA in your sample. Therefore, expect that yields of PCRs on bisulfite-converted DNA to be significantly less than standard PCRs, and will often require additional cycles to produce a usable amount of product. 
+
+* The deamination of cytosine produces uracil. Copies of the region with thymine are produced during the PCR. Therefore, the polymerase used must be able to amplify off uracil-containing templates. Refer to the manufacturer’s product information sheets to identify if your polymerases are suitable for amplification off bisulfite-converted DNA.
+
+* PCRs on bisulfite-converted DNA are often more sensitive to changes to annealing temperature than conventional PCRs. During the optimization of primer pairs for bisulfite-converted DNA, I would recommend optimizing with 1°C increments around the calculated annealing temperature of the primer pair. 
+
+## Equipment and Reagents
+### Reagents
+| Item | Cat. # | Concentration | Notes |
+| ---- | ------ | ------------- | ----- |
+| Phusion U Polymerase | F555S/L | | |
+| Invitrogen UltraPure Agarose | 16500-500 | N/A | |
+| Invitrogen SYBR Safe DNA Gel Stain | S33102 | 20000x | |
+| DMSO | N/A | 100% | |
+| dNTPs | N/A | 2 mM | |
+| Betaine | N/A | 5 M | |
+| Primers | N/A | 5 uM | Forward and reverse primers |
+| Template DNA | N/A | >0.25 ng/uL | |
+
+### Equipment/Consumables
+| Equipment | Consumables |
+| --------- | ----------- |
+| Thermocyclers | PCR tubes/strips |
+| Micropipettes | Pipette tips |
+| Microcentrifuge | Microcentrifuge tubes |
+| Table-top vortex | |
+
+## Protocol 
+1. Prepare a master-mix for your PCR. Below is a recommended starting recipe for a 10 uL reaction volume BSPCR. 
+
+    #### Table 1: BSPCR master-mix
+    | Reagent                      | Volume (uL)  | Final Concentration (10 uL Rxn) |
+    | ---------------------------- | ------------ | ------------------------------- |
+    | Phusion GC Buffer, 5X        | 2            | 1X                              |
+    | Betaine, 5M                  | 2            | 1M                              |
+    | dNTPs, 2mM                   | 1            | 0.8 mM                          |
+    | Nuclease-free water          | 0.6          | \-                              |
+    | DMSO                         | 0.3          | 3%                              |
+    | FW & REV Primer, 5 µM        | 1 (for each) | 0.5 µM                          |
+    | Phusion U Polymerase, 2 U/uL | 0.1          | 0.2 U                           |
+    
+    When preparing the master mix, combine all components other than the polymerase and vortex well. Afterwards, add the polymerase and mix well via flicking and inversion. Vortexing is also possible but keep the pulses as small as possible (e.g. 0.5 seconds). Centrifuge after mixing. 
+2. Deliver the appropriate volume of master-mix for each reaction you are preparing. If the master-mix contains the primers, then 8 uL of master-mix should be aliquoted. If not, 6 uL of master-mix should be aliquoted, assuming that you are adding 1 uL of 5 uM forward and reverse primers, respectively.
+3. Add primers then the template DNA (2 uL, dilute if necessary) into each aliquot. 
+4. Mix the PCR reactions well via vortexing or flicking and inverting the tubes, then centrifuge.
+    * Vortexing briefly seems to produce more consistent results than flicking and inverting the tubes. 
+5. Load the tubes into a thermocycler, and use the following program: 
+    #### Table 3: Thermocycling protocol for Phusion U 
+    | Temperature | Duration  |
+    | ----------- | --------- |
+    | 98°C        | 30s       |
+    | 98°C        | 10s (x40) |
+    | X°C         | 30s (x40) |
+    | 72°C        | 30s (x40) |
+    | 72°C        | 10 min    |
+6. To confirm the success of the PCR, perform agarose gel electrophoresis. Prepare a 2% gel. Load 3 uL of PCR product mixed with 3 uL of loading dye into each well. Load 1 uL of ladder mixed with 3 uL of loading dye and 3 uL of water. Run the gel at 120 V for 40 minutes. 
+7. For PCR optimization, prepare 6-9 replicates of each PCR and test them in 1 C increments in the Quantstudio 5. These PCR sets are extremely sensitivie to the annealing temperature. 
+
+## References
+1. Thermoscientific. (n.d.). Phusion U Hot Start. [Link.](https://assets.thermofisher.com/TFS-Assets/LSG/manuals/MAN0012916_PhusionUHotStart_DNAPolymerase_F555L_UG.pdf)
+	
+2. Darst, R. P., Pardo, C. E., Ai, L., Brown, K. D., & Kladde, M. P. (2010). Bisulfite sequencing of DNA. Current Protocols in Molecular Biology / Edited by Frederick M. Ausubel... [et Al.], Chapter 7, Unit 7.9.1–17.

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -174,7 +174,7 @@ results/
 ### Generating QC results for the entire run
 #### Review the `fastqc` and `multiqc` results
 This protocol will not go over how to interpret `fastqc` results. A basic tutorial can be found [here](https://rtsf.natsci.msu.edu/genomics/tech-notes/fastqc-tutorial-and-faq/). `multiqc` is a useful tool for summarizing all of the fastqc results from a single run. The results (`.html` files) for both tools can be viewed in a web browser. 
-#### `process-bismark-reports.py` and `process-bismark-incomplete-reports.py`
+#### process-bismark-reports.py and process-bismark-incomplete-reports.py
 `process-bismark-reports.py` generates a .csv file containing summary statistics of the read mapping for each sample. It crawls through the `report.txt` files and extracts the relevant information. To use this script, run the following command: 
 ```
 python ./process-bismark-reports.py <bismark/mapped_bam> -o </path/to/results/directory>
@@ -185,7 +185,7 @@ python ./process-bismark-incomplete-reports.py <bismark/incomplete_conv_bam> -o 
 ```
 In a future revision of this pipeline, both scripts will be combined. For now, the data from both .csv files has to be manually combined to yield the final run results .csv file. The percentage of usable reads can now be determined. 
 
-### `process-bismark-coverage.py`
+### process-bismark-coverage.py
 The purpose of the script is to generate sample summary files and human-readable .csv files of the methylation call data. The outputs of this script are used in downstream analysis scripts. To run the script, run the following command: 
 
 ```
@@ -219,14 +219,14 @@ A `sample-name_summary.csv` file is generated for each sample, and summarizes th
 
 Each row corresponds to a target site that there is data for. `#CG_total` refers to the total number of `CG` sites in the target region. `#CG_covered` refers to the number of `CG` sites in the region that have data for. `mean_methylation` and `std_methylation` are the summary statistics for the methylation status of the entire target site. `mean_coverage` and `std_coverage` are summary statistics for the number of reads that contribute to the calls of the region. 
 
-### `cgvisualizer.py`
+### cgvisualizer.py
 This script plots the methylation calls for each target site for each sample. The input files for this script are the coverage files and the primer.bed file. To run the script, run the following command: 
 ```
 python ./cgvisualizer.py </path/to/coverage-files> </path/to/primer.bed> -o <results/>
 ```
 Each sample gets its own `.png` file containing the methylation plots for all 21 target sites. Target sites that do not have data are labeled as 'no data'. There is also a line plot that corresponds to the coverage at each `CG` position overlayed on top of the methylation plot. 
 
-### `assess-by-primer.py`
+### assess-by-primer.py
 This script generates box plots of the site coverage for each primer set. The input files are the `sample-name_summary.csv` files from `process-bismark-coverage.py` for the group of samples that you want to analyze together, as well as a `sample-sequences.csv` file containing two columns: the sample names, and the final number of usable reads (refer to QC steps to get this value). To run the script, run the following command: 
 ```
 python ./assess-by-primer.py </path/to/sample-name_summary.csv> -n </path/to/sample-sequences.csv> -t <tag> -o <results/>

--- a/ngs_process_bismark/cgvisualizer.py
+++ b/ngs_process_bismark/cgvisualizer.py
@@ -190,13 +190,44 @@ def generate_figure(
     None; writes figure .png to specified directory. 
     
     """
-    fig, axs = pyplot.subplots(7, 3, figsize=(8.5,11))
+    #Calculate the number of subplots that should exist
+    #Currently, our primer sets look like this: 
+    #BS-Run-1 : 30 sets
+    #BS-Run-2 : 20 sets
+    #BSX-Run-2: 16 sets
+    #BSX-Run-3: 21 sets
+
+    #TODO: do not hardcode these plots
+    #Current implementation - based on the number of primers, generate 
+    # the appropriate width and height params to fit all samples
+    num_primers = len(primer_data)
+    print(num_primers)
+    if num_primers == 30: 
+        height = 10
+        width = 3
+    elif num_primers == 21:
+        height = 7
+        width = 3
+    elif num_primers == 20: 
+        height = 10
+        width = 2
+    elif num_primers == 16: 
+        height = 8
+        width = 2
+    else: 
+        print('NUMBER OF PRIMERS NOT USED IN BOVITEQ PROJECT.')
+        print('PROGRAM CANNOT CONTINUE. FUTURE IMPLEMENTATION WILL FIX THIS ISSUE')
+        exit() 
+
+
+
+    fig, axs = pyplot.subplots(height, width, figsize=(8.5,11))
     
     region_index = 0
     #Iterate through each of the 21 plots
     #Each plot specified as axs[i][j]
-    for i in range(7): 
-        for j in range(3): 
+    for i in range(height): 
+        for j in range(width): 
             
             primer = region_data[region_index]['primer']
             #pos_data = region_data[region_index]['positions']
@@ -257,7 +288,9 @@ def generate_figure(
             )
             axs[i][j].set_yticks(
                 (0, 50.0, 100.0),
-                labels=('0%', '50%', '100%')
+            )
+            axs[i][j].set_yticklabels(
+                ('0%', '50%', '100%')
             )
             region_index = region_index + 1
     

--- a/ngs_process_bismark/process-bismark-coverage.py
+++ b/ngs_process_bismark/process-bismark-coverage.py
@@ -146,20 +146,23 @@ def process_coverage_data(primer_data: list, coverage_df: pd.DataFrame):
                 coverage_std = 0
             under_coverage = sum(primer_df['coverage'] < coverage_avg)
 
-            summary_data.append(
-                (
-                    primer.primer,
-                    primer.num_cg,
-                    number_cg,
-                    methylation_avg, 
-                    methylation_std, 
-                    coverage_avg, 
-                    coverage_std,
-                    under_coverage
+            if primer_df.empty: 
+                pass
+            else: 
+                summary_data.append(
+                    (
+                        primer.primer,
+                        primer.num_cg,
+                        number_cg,
+                        methylation_avg, 
+                        methylation_std, 
+                        coverage_avg, 
+                        coverage_std,
+                        under_coverage
+                        )
                     )
-                )
 
-            primer_dfs[primer.primer] = primer_df
+                primer_dfs[primer.primer] = primer_df
 
             #print(primer_df)
             #print(f'{primer.primer} mean methylation: {methylation_avg}')


### PR DESCRIPTION
The scripts were designed for just the most recent run of 21 primers with only single strand coverage. The scripts are now modified to allow for analysis of different number of primers and to account for a bug that occurs when data is available for only one strand but primers for both strands are within dataset. 